### PR TITLE
ci: fix GHCR push 403 by using github.actor

### DIFF
--- a/.github/workflows/docker-publish-tag.yml
+++ b/.github/workflows/docker-publish-tag.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels)
@@ -55,4 +55,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,7 +34,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels)


### PR DESCRIPTION
- Use `${{ github.actor }}` for GHCR login instead of `${{ github.repository_owner }}` to align username with GITHUB_TOKEN owner and avoid 403 on push.
- Applies to both main and tag workflows.

Error observed:

> failed to push ghcr.io/toof-jp/healthcheck:latest: unexpected status from HEAD request ... 403 Forbidden

After merge, rerun the workflow to confirm successful push.
