### PR TITLE
docs: update README to reference home-kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # healthcheck
+
+This repository is a minimal test application used as a healthcheck target for [toof-jp/home-kubernetes](https://github.com/toof-jp/home-kubernetes).


### PR DESCRIPTION
This PR updates the README to clearly state that this repository is a minimal healthcheck test application used by [toof-jp/home-kubernetes](https://github.com/toof-jp/home-kubernetes).